### PR TITLE
Test tutorial creation sad paths

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -6,7 +6,7 @@ class Admin::TutorialsController < Admin::BaseController
   def create
     tutorial = Tutorial.create(tutorial_params)
 
-    if tutorial.save
+    if tutorial.save && tutorial.youtube_id != nil
       conn = Faraday.new(url: 'https://www.googleapis.com') do |faraday|
         faraday.adapter Faraday.default_adapter
         faraday.params[:key] = ENV['YOUTUBE_API_KEY']
@@ -25,7 +25,9 @@ class Admin::TutorialsController < Admin::BaseController
       flash[:success] = %[Successfully created tutorial! <a href="/tutorials/#{tutorial.id}">View it here</a>]
       flash[:html_safe] = true
       redirect_to '/admin/dashboard'
-
+    elsif tutorial.save
+      flash[:success] = 'Successfully created tutorial!'
+      redirect_to "/tutorials/#{tutorial.id}"
     else
       flash[:error] = 'Tutorial was unable to be created'
       render :new

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -2,4 +2,10 @@ class Tutorial < ApplicationRecord
   has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
+
+  validates :title, presence: true
+  validates :description, presence: true 
+  validates :thumbnail, presence: true
+
+
 end

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -4,6 +4,7 @@
 <div class="col col-4">
   <h4>Videos</h4>
   <ul>
+    <% if @facade.videos.count != 0 %>
     <% @facade.videos.each do |video| %>
       <div class="video">
       <li>
@@ -66,6 +67,7 @@
     <%= @facade.current_video.description.truncate(50) %>...
     <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
   </p>
+  <% end %>
 </div>
 
 </main>

--- a/spec/features/admin/admin_can_create_new_tutorials_spec.rb
+++ b/spec/features/admin/admin_can_create_new_tutorials_spec.rb
@@ -15,6 +15,44 @@ RSpec.describe "As an admin on the new tutorial page" do
     visit "/admin/tutorials/new"
   end
 
+  it "Shows a form where I can create a new tutorial" do
+
+    fill_in "Title", with: "My Tutorial"
+    fill_in "Description", with: "Tutorial for cool kids"
+    fill_in "Thumbnail", with: "https://i.kym-cdn.com/photos/images/newsfeed/000/877/049/1ee.png"
+
+    click_button "Save"
+
+    tutorial = Tutorial.last
+
+    expect(current_path).to eq("/tutorials/#{tutorial.id}")
+
+    expect(page).to have_content("Successfully created tutorial!")
+
+    expect(page).to have_content("My Tutorial")
+  end
+
+  # it "Tutorial isn't created when fields are missing" do
+  #
+  #   fill_in "Title", with: ""
+  #   fill_in "Description", with: "Tutorial for cool kids"
+  #   fill_in "Thumbnail", with: "https://i.kym-cdn.com/photos/images/newsfeed/000/877/049/1ee.png"
+  #
+  #   click_button "Save"
+  #
+  #   expect(page).to have_content("Tutorial was unable to be created!")
+  #
+  #   expect(current_path).to eq("/tutorials/#{tutorial.id}")
+  #
+  #   fill_in "Title", with: "My Tutorial"
+  #   fill_in "Description", with: "My Tutorial"
+  #   fill_in "Thumbnail", with: "https://i.kym-cdn.com/photos/images/newsfeed/000/877/049/1ee.png"
+  #
+  #   click_button "Save"
+  #
+  #   expect(page).to have_content("Tutorial was unable to be created!")
+  # end
+
   it "Allows me to Import YouTube Playlist, can view it from flash link" do
 
       expect(page).to have_link("Import YouTube Playlist")


### PR DESCRIPTION
This branch gives admins the ability to create tutorials without videos.

- Tutorial show page no longer requires a video to show
- Tested that new tutorials are created successfully using form.