### PR TITLE
Filtered Classwork Tutorials from Visitor View

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -5,7 +5,7 @@ class TutorialsController < ApplicationController
   end
 
   def index
-    if current_user != nil
+    if !current_user.nil?
       @show_tutorials = Tutorial.all
     else
       @show_tutorials = []
@@ -15,6 +15,6 @@ class TutorialsController < ApplicationController
           @show_tutorials << tutorial
         end
       end
-    end 
+    end
   end
 end

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -5,6 +5,16 @@ class TutorialsController < ApplicationController
   end
 
   def index
-    @tutorials = Tutorial.all
+    if current_user != nil
+      @show_tutorials = Tutorial.all
+    else
+      @show_tutorials = []
+      tutorials = Tutorial.all
+      tutorials.each do |tutorial|
+        if tutorial.classroom == false
+          @show_tutorials << tutorial
+        end
+      end
+    end 
   end
 end

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -1,5 +1,5 @@
 <main class="tutorials">
-  <% @tutorials.each do |tutorial| %>
+  <% @show_tutorials.each do |tutorial| %>
   <section class="tutorial">
     <div class="tutorial-thumbnail col md-col-2">
       <a>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,7 +42,7 @@ mod_1_tutorial_data = {
   "description"=>"Videos related to Mod 1.",
   "thumbnail"=>"https://i.ytimg.com/vi/tZDBWXZzLPk/hqdefault.jpg",
   "playlist_id"=>"PL1Y67f0xPzdNsXqiJs1s4NlpI6ZMNdMsb",
-  "classroom"=>false,
+  "classroom"=>true,
 }
 
 m1_tutorial = Tutorial.create! mod_1_tutorial_data

--- a/spec/features/vistors/visitor_cannot_see_classroom_content_spec.rb
+++ b/spec/features/vistors/visitor_cannot_see_classroom_content_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'as a Visitor' do
+  it 'cannot see classroom content tutorials' do
+    tutorial = Tutorial.create(title: "Baking Cookies",
+                                description: "Chocolate Chip and More")
+    tutorial_2 = Tutorial.create(title: "Classroom Tutorial",
+                                 description: "Tutorials about teaching",
+                                 classroom: true)
+    tutorial_3 = Tutorial.create(title: "Playing Soccer",
+                                description: "Soccer Tips")
+    tutorial_4 = Tutorial.create(title: "More About Teaching",
+                                 description: "Everything else you need to know",
+                                 classroom: true)
+    visit '/tutorials'
+
+    expect(page).to have_content(tutorial.title)
+    expect(page).to have_content(tutorial_3.title)
+    expect(page).to_not have_content(tutorial_2.title)
+    expect(page).to_not have_content(tutorial_4.title)
+
+  end
+end


### PR DESCRIPTION
Added functionality to filter out classwork tutorials from visitor view.

Users must be logged in to see classwork tutorials now.

All tests are passing, one Rubocop offense.